### PR TITLE
Name module correctly, update usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,17 @@ Go Persian Calendar
 
 ## Installation
 
-- Add `ptime` to `go.mod`:
+This assumes you're using go modules, and have set up your `go.mod` file,
+possibly using `go mod init`.
+
+-- Import it in your code:
 
 ```
-require github.com/yaa110/go-persian-calendar/ptime v0.3.1
+import ptime github.com/yaa110/go-persian-calendar
 ```
+
+-- Building using `go build` will now automatically get go-persian-calendar and
+   update your `go.mod``
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import ptime github.com/yaa110/go-persian-calendar
 
 ```go
 import (
-    "github.com/yaa110/go-persian-calendar/ptime"
+    ptime "github.com/yaa110/go-persian-calendar"
     "time"
     "fmt"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/yaa110/go-persian-calendar/ptime
+module github.com/yaa110/go-persian-calendar

--- a/ptime_test.go
+++ b/ptime_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/yaa110/go-persian-calendar/ptime"
+	. "github.com/yaa110/go-persian-calendar"
 )
 
 type pMonthName struct {


### PR DESCRIPTION
I failed to use the ptime package, given how you named your module. I'm actually somewhat of a beginner using go modules. It does seem to me though that the module name should be a precise import path. As in, "we're rooted here".
