### PR TITLE
improve Format() performance

### DIFF
--- a/ptime.go
+++ b/ptime.go
@@ -264,14 +264,11 @@ func (d Weekday) Short() string {
 
 // String returns the Persian name of 12-Hour marker.
 func (a AmPm) String() string {
-	switch {
-	case a < 0:
+	if a <= 0 { // Am
 		return amPm[0]
-	case a > 1:
-		return amPm[1]
-	default:
-		return amPm[a]
 	}
+
+	return amPm[1] // Pm
 }
 
 // Short returns the Persian short name of 12-Hour marker.
@@ -605,12 +602,11 @@ func (t Time) Hour() int {
 
 // Hour12 returns the hour of t in the range [0, 11].
 func (t Time) Hour12() int {
-	h := t.hour
-	if h >= 12 {
-		h -= 12
+	if t.hour >= 12 {
+		return t.hour - 12
 	}
 
-	return h
+	return t.hour
 }
 
 // Minute returns the minute offset of t in the range [0, 59].
@@ -835,11 +831,10 @@ func isLeap(year int) bool {
 
 // AmPm returns the 12-Hour marker of t.
 func (t Time) AmPm() AmPm {
-	m := Am
 	if t.hour > 12 || (t.hour == 12 && (t.min > 0 || t.sec > 0)) {
-		m = Pm
+		return Pm
 	}
-	return m
+	return Am
 }
 
 // Zone returns the zone name and its offset in seconds east of UTC of t.
@@ -1330,7 +1325,7 @@ func (t *Time) normDay() {
 
 func modifyHour(value, max int) int {
 	if value == 0 {
-		value = max
+		return max
 	}
 	return value
 }

--- a/ptime_test.go
+++ b/ptime_test.go
@@ -2,6 +2,7 @@ package ptime_test
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -606,4 +607,16 @@ func TestHourName(t *testing.T) {
 			}
 		}
 	}
+}
+
+func BenchmarkFormat(b *testing.B) {
+	now := Now()
+
+	var s string
+
+	for i := 0; i < b.N; i++ {
+		s = now.Format("A D E H HH K KK MM MMM MMI MM RD R S W Z a dd d e hh h kk k mm m ns nr rw rd ss s w y yyyy yyy yy z")
+	}
+
+	runtime.KeepAlive(s)
 }


### PR DESCRIPTION
This refactoring improves the performance of the `Format()`.

```console
$ go test -bench=. -benchmem -count=10 > a.txt # before changes
$ go test -bench=. -benchmem -count=10 > b.txt # after changes
$ benchstat a.txt b.txt                                 
goos: darwin
goarch: arm64
pkg: github.com/yaa110/go-persian-calendar
cpu: Apple M2 Max
          │    a.txt     │                b.txt                │
          │    sec/op    │   sec/op     vs base                │
Format-12   3440.0n ± 1%   822.5n ± 1%  -76.09% (p=0.000 n=10)

          │    a.txt    │               b.txt                │
          │    B/op     │    B/op     vs base                │
Format-12   5995.0 ± 0%   256.0 ± 3%  -95.73% (p=0.000 n=10)

          │   a.txt    │                b.txt                │
          │ allocs/op  │  allocs/op   vs base                │
Format-12   64.00 ± 2%   10.00 ± 10%  -84.38% (p=0.000 n=10)
```